### PR TITLE
add Tailwind boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 _site
 .jekyll-metadata
-*.css
 .DS_Store
 .sass-cache/
 .jekyll-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-_site
-.jekyll-metadata
 .DS_Store
-.sass-cache/
-.jekyll-cache
 node_modules
-
 .astro
 dist

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,40 @@
+---
+import Navbar from "../components/Navbar.astro";
+import Footer from "../components/Footer.astro";
+
+import "../styles/app.css";
+
+interface Props {
+  title: string;
+  description?: string | undefined;
+}
+
+const { title, description } = Astro.props;
+---
+
+<html>
+  <head>
+    <title>{title}</title>
+    {
+      description && (
+        <meta
+          name="description"
+          content={description}
+        />
+      )
+    }
+    <link
+      rel="icon"
+      href="/favicon.png"
+    />
+    <meta
+      http-equiv="Content-Type"
+      content="text/html; charset=utf-8"
+    />
+  </head>
+  <body class="bg-neutral-900 text-white min-h-screen">
+    <Navbar />
+    <slot />
+    <Footer />
+  </body>
+</html>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,26 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-display;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  :any-link {
+    @apply text-red-500;
+  }
+  :any-link:hover {
+    @apply text-red-600;
+  }
+  :any-link:visited {
+    @apply text-red-700;
+  }
+  :any-link:visited:hover {
+    @apply text-red-600;
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,10 +1,31 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+	content: ['./src/components/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
+		"./src/layouts/**/*.{astro,html}",
+		"./src/pages/**/*.{astro,html}",
+	],
 	theme: {
-		colors: {
-			red: "#e83224"
-		}
+		extend: {
+			colors: {
+				red: {
+					'50': '#fff2f1',
+					'100': '#ffe2e0',
+					'200': '#ffcbc7',
+					'300': '#ffa7a0',
+					'400': '#ff7469',
+					'500': '#f9483a',
+					'600': '#e83224',
+					'700': '#c31f12',
+					'800': '#a11d13',
+					'900': '#851f17',
+					'950': '#490b06',
+				},
+			},
+		},
+		fontFamily: {
+			sans: ['Open Sans', 'sans-serif'],
+			display: ["Montserrat", "sans-serif"],
+		},
 	},
 	plugins: [],
 }


### PR DESCRIPTION
Add a `Layout` component for making sure Tailwind is included properly across all pages and simplify page structure, and add a CSS file for extending the default styles
Also: update .gitignore to remove references to Jekyll-specific files/folders